### PR TITLE
Load all the tag groups from ${dir}/.ts/tsm.json

### DIFF
--- a/data/js/directories.ui.js
+++ b/data/js/directories.ui.js
@@ -136,8 +136,11 @@ define(function(require, exports, module) {
             //console.log("Location Metadata: "+JSON.stringify(metadata));
 
             if(metadata.tagGroups.length > 0) {
-                TSCORE.locationTags = metadata.tagGroups[0].children;
+                TSCORE.locationTags = metadata.tagGroups;
                 TSCORE.generateTagGroups();
+            }
+            else {
+                TSCORE.locationTags = null;
             }
 
             /*if(metadata.desktop !== undefined) {

--- a/data/js/tags.ui.js
+++ b/data/js/tags.ui.js
@@ -232,14 +232,11 @@
             });
         }
 
-        // Adding the locataion tag group
+        // Adding the locataion tag groups
         if(TSCORE.Config.getLoadLocationMeta() && TSCORE.locationTags !== null) {
-            tagGroups.push({
-                "title": $.i18n.t("ns.common:tagsFromCurrentLocation"),
-                "key": locationTagGroupKey,
-                "expanded": true,
-                "children": TSCORE.locationTags
-            });
+            for (var i=0;i<TSCORE.locationTags.length;i++) {
+                tagGroups.push(TSCORE.locationTags[i]);
+            }
         }
 
         // ehnances the taggroups with addition styling information


### PR DESCRIPTION
I'm not sure what to do with https://github.com/uggrock/tagspaces/blob/master/data/js/tags.ui.js#L11 after making the change to load all the tag groups from the tsm.json.
