### PR TITLE
Use fs.rename instead of fs.link for renaming (and tagging) files

### DIFF
--- a/data/electron/electron.api.js
+++ b/data/electron/electron.api.js
@@ -528,7 +528,7 @@ define(function(require, exports, module) {
       if (fs.existsSync(newFilePath)) {
         reject($.i18n.t("ns.common:fileExists", {fileName:newFilePath}), $.i18n.t("ns.common:fileRenameFailed"));
       }
-      fs.move(filePath, newFilePath, function(error) {
+      fs.move(filePath, newFilePath, {clobber:true}, function(error) {
         if (error) {
           reject("Renaming: " + filePath + " failed.");
         }

--- a/data/locales/en_US/ns.common.json
+++ b/data/locales/en_US/ns.common.json
@@ -213,7 +213,7 @@
     "enjoyTitle": "Enjoy using TagSpaces!",
     "thankyouContent": "... and thank you for your attention.",
     "services": "Services",
-    "hideTagspaces": "Hide TagSpaces",
+    "hideTagSpaces": "Hide TagSpaces",
     "hideOthers": "Hide Others",
     "showAll": "Show All",
     "quit": "Quit",


### PR DESCRIPTION
Currently network shares (afp on mac os x for example) are not fully supported since it's not possible to create hard links on them. ( see #358 )

The flag enabled overwriting files (but this is already checked before). The more important thing about the flag is that it causes the underlying api to use fs.rename instead of fs.link which works on (at least AFP) network shares.