### PR TITLE
correctly handle animated GIFs

### DIFF
--- a/data/web/thumbgen.sh
+++ b/data/web/thumbgen.sh
@@ -14,6 +14,7 @@ generate_thumbnails() {
     do
       # next line checks the mime-type of the file
       CHECKTYPE=`file --mime-type -b "$file" | awk -F'/' '{print $1}'`
+      CHECKFORMAT=`file --mime-type -b "$file" | awk -F'/' '{print $2}'`
       if [ "x$CHECKTYPE" == "ximage" ]; 
     then
         thumbfile="$thumbdir/$(basename "$file").png"
@@ -39,6 +40,10 @@ generate_thumbnails() {
         # next 'if' is true if either filesize >= 200000 bytes  OR  if image width >=201
         if [ $CHECKSIZE -ge  200000 ] || [ $CHECKWIDTH -ge 201 ]; then
             echo "$file -> $thumbfile" 
+            if [ $CHECKFORMAT == "gif" ]; then
+              # if image is animated gif we only want 1st frame
+              file="$file[0]"
+            fi
             convert -thumbnail 400 "$file" "$thumbfile"
         fi
       fi


### PR DESCRIPTION
When calling _ImageMagic convert_ on animated GIFs it processes every frame of animation; generated thumbnails are not usable since resulting filename does not conform - ex. if we have file _ani.gif_ with 4 frames _thumben.sh_ generates
.ts/ani.gif-0.png
.ts/ani.gif-1.png
.ts/ani.gif-2.png
.ts/ani.gif-3.png

This fix directs _convert_ to only process 1st frame,
if GIF is not animated calling convert this way doesn't affect the processing.
