### PR TITLE
Ignore file/dir names that start with dot, instead of ignoring all paths that do.

### DIFF
--- a/data/js/perspective.manager.js
+++ b/data/js/perspective.manager.js
@@ -211,7 +211,7 @@ define(function(require, exports, module) {
 
     for (var i = 0; i < dirList.length; i++) {
       // Considering Unix HiddenEntries (. in the beginning of the filename)
-      if (TSCORE.Config.getShowUnixHiddenEntries() || !TSCORE.Config.getShowUnixHiddenEntries() && dirList[i].path.indexOf(TSCORE.dirSeparator + '.') < 0) {
+      if (TSCORE.Config.getShowUnixHiddenEntries() || !TSCORE.Config.getShowUnixHiddenEntries() && (dirList[i].name.length && dirList[i].name[0] != '.')) {
         filename = dirList[i].name.replace(/(<([^>]+)>)/gi, ''); // sanitizing filename
         path = dirList[i].path.replace(/(<([^>]+)>)/gi, ''); // sanitizing filepath
         title = TSCORE.TagUtils.extractTitle(filename);


### PR DESCRIPTION
Fixes #494.
