### PR TITLE
settings: Cap max result to 2000 instead of setting limit to 0

### DIFF
--- a/data/js/settings.api.js
+++ b/data/js/settings.api.js
@@ -818,8 +818,10 @@ define(function(require, exports, module) {
   }
 
   function setMaxSearchResultCount(value) {
-    if (isNaN(value) || value < 0 || value > 2000) {
-      value = 0;
+    if (isNaN(value) || value < 0) {
+      value = exports.DefaultSettings.maxSearchResultCount;
+    } else if (value > 2000) {
+      value = 2000;
     }
     exports.Settings.maxSearchResultCount = value;
   }


### PR DESCRIPTION
Trying to adjust the settings for the max amount of files to 10000, then
saving, showed the GUI without any files at all. Being a new user,  the
program seemed buggy. There is no indication of files being loaded even
though the limit was increased and the directory pointed at contained a
lot of files, no perceived sluggishness.

Reopening the settings window shows 0 as a new limit. The limit should
never be that low, because it may fool the user. When detecting an
invalid value, the default value should be applied. When detecting a
"too high" value, the value should be capped, not reset.

Signed-off-by: Carl Helmertz <helmertz@gmail.com>