### PR TITLE
Bookmark button in ff extension

### DIFF
--- a/data/mozilla/main.js
+++ b/data/mozilla/main.js
@@ -97,8 +97,9 @@ function openTagSpacesInNewTab() {
 
 function initToobarButton() {
   var tagspacesPanel = new Panel({
-    width: 530,
-    height: 410,
+      width: 530,
+      //    height: 410,
+      height: 450,
     contentURL: data.url('mozilla/popup.html'),
     contentScriptFile: [ 
       data.url('libs/jquery/dist/jquery.min.js'),

--- a/data/mozilla/popup.html
+++ b/data/mozilla/popup.html
@@ -10,7 +10,7 @@ can be found in the LICENSE file.
     <title></title>
     <link rel="stylesheet" type="text/css" href="../assets/tagspaces.css">
 </head>
-<body style="width: 520px; height: 400px; padding:0; font-size: 14px; background-color: #f9f9f9;">
+<body style="width: 520px; height: 440px; padding:0; font-size: 14px; background-color: #f9f9f9;">
 <div class="well" style="margin: 0; border: 0px; background-color: transparent;">
     <div style="white-space: nowrap;" class="text-center">
         <img src="../assets/icon128.png" class="pull-left" style="margin-left: 20px; max-height: 32px; max-width: 32px;"/>&nbsp;&nbsp;
@@ -36,8 +36,13 @@ can be found in the LICENSE file.
         <a href="#" class="btn btn-primary" id="saveSelectionAsHtml" data-i18n-title="saveSelectionAsHtmlTitle">
             <i class="fa fa-file-text fa-lg fa-fw"></i>&nbsp;<span data-i18n="saveAsSelectionLabel">Save Selected</span>
         </a>
+    </div>
+    <div class="btn-toolbar text-center noWrap">
         <a href="#" class="btn btn-primary" id="saveScreenshot" data-i18n-title="saveScreenshotTitle">
             <i class="fa fa-camera fa-lg fa-fw"></i>&nbsp;<span data-i18n="saveScreenshotLabel">ScreenShoot</span>
+        </a>
+        <a href="#" class="btn btn-primary" id="saveBookmark" data-i18n-title="saveBookmarkTitle">
+          <i class="fa fa-file-url fa-lg fa-fw"></i>&nbsp;<span data-i18n="saveBookmarkLabel">Save Bookmark</span>
         </a>
     </div>
 </div>

--- a/data/mozilla/popup.js
+++ b/data/mozilla/popup.js
@@ -52,13 +52,24 @@
 
     function saveBookmark() {
         var tags = document.getElementById("tags").value;
-        var content = "<a href='" + currentURL + "'>" + currentURL + "</a>";
+        var content = generateURLFile( $('#title').val());
+//        var content = "<a href='" + currentURL + "'>" + currentURL + "</a>";
         if (tags) {
             tags = tags.split(",").join(" ");
-            self.port.emit('saveSelectionAsHtml', $('#title').val() + ' [' + tags + ' bookmark' + '].html', content);
+            self.port.emit('saveSelectionAsHtml', $('#title').val() + ' [' + tags + ' bookmark' + '].url', content);
         } else {
-            self.port.emit('saveSelectionAsHtml', $('#title').val() + '.html', content);            
+            self.port.emit('saveSelectionAsHtml', $('#title').val() + '.url', content);            
         }
+    }
+
+
+    function generateURLFile(title) {
+        return ["[Desktop Entry]",
+                "Encoding=UTF-8",
+                "Name=" + title,
+                "Type=Link",
+                "URL=" + currentURL
+               ].join('\n');
     }
     
   function saveScreenshot() { 

--- a/data/mozilla/popup.js
+++ b/data/mozilla/popup.js
@@ -22,6 +22,7 @@
     $("#saveAsMhtml").on('click', saveAsMHTML);
     $("#saveSelectionAsHtml").on("click", saveSelectionAsHtml);
     $("#saveScreenshot").on("click", saveScreenshot);
+    $("#saveBookmark").on("click", saveBookmark);  
   }
 
   function saveSelectionAsHtml() {
@@ -49,6 +50,17 @@
     }
   }
 
+    function saveBookmark() {
+        var tags = document.getElementById("tags").value;
+        var content = "<a href='" + currentURL + "'>" + currentURL + "</a>";
+        if (tags) {
+            tags = tags.split(",").join(" ");
+            self.port.emit('saveSelectionAsHtml', $('#title').val() + ' [' + tags + ' bookmark' + '].html', content);
+        } else {
+            self.port.emit('saveSelectionAsHtml', $('#title').val() + '.html', content);            
+        }
+    }
+    
   function saveScreenshot() { 
     var tags = document.getElementById("tags").value;
     if (tags) {


### PR DESCRIPTION
This branch adds a button the the Firefox web clipper that enables a simple bookmarking creation.

Initially, the button saved an anchor tag within an html file, but as per suggestions [here](https://github.com/tagspaces/tagspaces/issues/564), the button now generates a .url file suitable for reading by the viewerURL tagspaces extension.

Let me know if this suffices!