### PR TITLE
Allow passing options to convertMarkdown

### DIFF
--- a/data/js/utils.js
+++ b/data/js/utils.js
@@ -384,15 +384,17 @@ define(function(require, exports, module) {
     handleLinks($targetElement);
   }
 
-  function convertMarkdown(content) {
-    var mdOptions = {
-      gfm: true,
-      tables: true,
-      breaks: true,
-      pedantic: false,
-      sanitize: true,
-      smartLists: true,
-      smartypants: false
+  function convertMarkdown(content, mdOptions) {
+    if (!mdOptions) {
+      mdOptions = {
+        gfm: true,
+        tables: true,
+        breaks: true,
+        pedantic: false,
+        sanitize: true,
+        smartLists: true,
+        smartypants: false
+      }
     }
     if (marked) {
       return marked(content, mdOptions);


### PR DESCRIPTION
This is one half of the solution that will allow configuring options to the
marked library. tagspaces/viewerMD also needs to implement support for this.

This fixes #664.