### PR TITLE
Allow CmdOrCtrl+Q to quit

### DIFF
--- a/app/services/electron-menus.js
+++ b/app/services/electron-menus.js
@@ -129,7 +129,7 @@ export default function buildDesktopMenu(mainPageProps: Object) {
         }, */
         {
           label: i18n.t('core:exitApp'),
-          accelerator: '',
+          accelerator: (process.platform === 'darwin') ? 'Cmd+Q' : '',
           click: () => {
             ipcRenderer.send('quit-application', 'Bye, bye...');
           }

--- a/app/services/electron-menus.js
+++ b/app/services/electron-menus.js
@@ -129,7 +129,7 @@ export default function buildDesktopMenu(mainPageProps: Object) {
         }, */
         {
           label: i18n.t('core:exitApp'),
-          accelerator: (process.platform === 'darwin') ? 'Cmd+Q' : '',
+          accelerator: 'CmdOrCtrl+Q',
           click: () => {
             ipcRenderer.send('quit-application', 'Bye, bye...');
           }


### PR DESCRIPTION
Tagspaces v2 allowed pressing `cmd-q` to quit, this adds it for v3