### PR TITLE
Added the ability to select multiple files by holding the shift key.

### DIFF
--- a/app/perspectives/grid-perspective/src/index.js
+++ b/app/perspectives/grid-perspective/src/index.js
@@ -315,7 +315,19 @@ class GridPerspective extends React.Component<Props, State> {
 
   handleGridCellClick = (event, fsEntry: FileSystemEntry) => {
     const { selectedEntries } = this.state;
-    if (event.ctrlKey) {
+    if (event.ctrlKey && event.shiftKey) {
+      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === selectedEntries[selectedEntries.length - 1].path);
+      const currentSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === fsEntry.path);
+      const entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex + 0, currentSelectedIndex + 1);
+
+      this.setState(
+        {
+          selectedEntries: selectedEntries.concat(entriesToSelect)
+        },
+        this.computeFileOperationsEnabled
+      );
+      this.props.setLastSelectedEntry(fsEntry.path);
+    } else if (event.ctrlKey) {
       if (
         selectedEntries &&
         selectedEntries.some(entry => entry.path === fsEntry.path)
@@ -338,6 +350,17 @@ class GridPerspective extends React.Component<Props, State> {
         );
         this.props.setLastSelectedEntry(fsEntry.path);
       }
+    } else if (event.shiftKey) {
+      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === selectedEntries[0].path);
+      const currentSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === fsEntry.path);
+      const entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex, currentSelectedIndex + 1);
+
+      this.setState(
+        {
+          selectedEntries: (entriesToSelect)
+        },
+        this.computeFileOperationsEnabled
+      );
     } else {
       this.setState(
         {

--- a/app/perspectives/grid-perspective/src/index.js
+++ b/app/perspectives/grid-perspective/src/index.js
@@ -85,6 +85,7 @@ import DragItemTypes from '../../../components/DragItemTypes';
 import IOActions from '../../../reducers/io-actions';
 import {
   actions as AppActions,
+  getLastSelectedEntry,
 } from '../../../reducers/app';
 
 const maxDescriptionPreviewLength = 90;
@@ -316,9 +317,15 @@ class GridPerspective extends React.Component<Props, State> {
   handleGridCellClick = (event, fsEntry: FileSystemEntry) => {
     const { selectedEntries } = this.state;
     if (event.ctrlKey && event.shiftKey) {
-      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === selectedEntries[selectedEntries.length - 1].path);
+      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === this.props.lastSelectedEntry);
       const currentSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === fsEntry.path);
-      const entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex + 0, currentSelectedIndex + 1);
+      let entriesToSelect;
+
+      if (currentSelectedIndex > lastSelectedIndex) {
+        entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex, currentSelectedIndex + 1);
+      } else {
+        entriesToSelect = this.props.directoryContent.slice(currentSelectedIndex, lastSelectedIndex + 1);
+      }
 
       this.setState(
         {
@@ -351,13 +358,19 @@ class GridPerspective extends React.Component<Props, State> {
         this.props.setLastSelectedEntry(fsEntry.path);
       }
     } else if (event.shiftKey) {
-      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === selectedEntries[0].path);
+      const lastSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === this.props.lastSelectedEntry);
       const currentSelectedIndex = this.props.directoryContent.findIndex(entry => entry.path === fsEntry.path);
-      const entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex, currentSelectedIndex + 1);
+      let entriesToSelect;
+
+      if (currentSelectedIndex > lastSelectedIndex) {
+        entriesToSelect = this.props.directoryContent.slice(lastSelectedIndex, currentSelectedIndex + 1);
+      } else {
+        entriesToSelect = this.props.directoryContent.slice(currentSelectedIndex, lastSelectedIndex + 1);
+      }
 
       this.setState(
         {
-          selectedEntries: (entriesToSelect)
+          selectedEntries: entriesToSelect
         },
         this.computeFileOperationsEnabled
       );
@@ -1191,7 +1204,8 @@ function mapActionCreatorsToProps(dispatch) {
 
 function mapStateToProps(state) {
   return {
-    supportedFileTypes: getSupportedFileTypes(state)
+    supportedFileTypes: getSupportedFileTypes(state),
+    lastSelectedEntry: getLastSelectedEntry(state),
   };
 }
 


### PR DESCRIPTION
Added the ability to select multiple files by holding the shift key.
Added the ability to add multiple files to the selection by holding the shift + ctrl key.

I was looking for a program to tag files and filter by tag and found what I was looking for in TagSpaces. Unfortunately, the feature to select multiple files without having to click on each one individually was missing. It seems like this is what several people have been requesting (https://github.com/tagspaces/tagspaces/issues/686, https://github.com/tagspaces/tagspaces/issues/689).

I'm a c++ developer with no prior knowledge about javascript but I figured I could do this. Two days later I've learned the basics of javascript and implemented the core of the requested feature. You can select multiple files with shift and add multiple files to the selection with ctrl + shift. Unfortunately, I wasn't able to implement this feature as well as I would have liked. 

At this point, you can select multiple files when trying to select files from the top to bottom but you cannot select multiple files when going from bottom to top. To properly do that I need to get the LastSelectedEntry, but I can't figure out how to access that. Maybe @uggrock can help or improve on this feature.

![tagspaces_selectmultiple_01](https://user-images.githubusercontent.com/1915778/51444014-17e41e00-1cf2-11e9-8b72-77a12dda9e1a.gif)

![tagspaces_selectmultiple_02](https://user-images.githubusercontent.com/1915778/51444017-1d416880-1cf2-11e9-8dfd-8fe600aa450e.gif)