### PR TITLE
Updated split pane resizer style

### DIFF
--- a/app/assets/splitpane.css
+++ b/app/assets/splitpane.css
@@ -11,8 +11,10 @@
 }
 
 .Resizer:hover {
-  -webkit-transition: all 2s ease;
-  transition: all 2s ease;
+  -webkit-transition: margin 0s;
+  transition: margin 0s;
+  -webkit-transition: border-color 2s;
+  transition: border-color 2s;
 }
 
 .Resizer.horizontal {
@@ -30,14 +32,16 @@
 }
 
 .Resizer.vertical {
-  width: 11px;
-  margin: 0 -5px;
-  border-left: 5px solid rgba(255, 255, 255, 0);
+  width: 6px;
+  margin: 0 -5px 0 0px;
+  border-left: 0px solid rgba(255, 255, 255, 0);
   border-right: 5px solid rgba(255, 255, 255, 0);
   cursor: col-resize;
 }
 
 .Resizer.vertical:hover {
+  width: 11px;
+  margin: 0 -5px 0 -5px;
   border-left: 5px solid rgba(0, 0, 0, 0.5);
   border-right: 5px solid rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Updated split pane resizer style to prevent the divider from overlapping with the scroll bar.

This fixes an annoying behavior where one would grab the divider instead of the scroll bar when the side panel is closed and the mouse moved to the right edge of the screen.