### PR TITLE
Remove width restriction on TagGroup container

### DIFF
--- a/app/components/TagLibrary.js
+++ b/app/components/TagLibrary.js
@@ -240,7 +240,7 @@ class TagLibrary extends React.Component<Props, State> {
           </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
-      <Collapse in={tagGroup.expanded} unmountOnExit style={{ maxWidth: 250 }}>
+      <Collapse in={tagGroup.expanded} unmountOnExit>
         <TagGroupContainer taggroup={tagGroup} data-tid={'tagGroupContainer_' + tagGroup.title}>
           {tagGroup.children && tagGroup.children.map((tag: Tag) => (
             <TagContainerDnd


### PR DESCRIPTION
I don't see any reason to clamp the width of the TagGroup container to 250 px when you can expand the side panel further than that. It's just a lot of wasted space when working with many tags.

Compare before and after:
![taggroupwidth_01](https://user-images.githubusercontent.com/1915778/51989011-6473ea00-24a6-11e9-8c58-f244ef7c6757.jpg)
![taggroupwidth_02](https://user-images.githubusercontent.com/1915778/51989015-66d64400-24a6-11e9-8feb-47fad4ff4551.jpg)
