### PR TITLE
Compact TagContainer and list view styles

### DIFF
--- a/app/components/TagContainer.js
+++ b/app/components/TagContainer.js
@@ -76,7 +76,9 @@ class TagContainer extends React.Component<Props> {
         <RemoveTagIcon
           data-tid={'tagRemoveButton_' + tag.title.replace(/ /g, '_')}
           style={{
-            color: tag.textColor
+            color: tag.textColor,
+            fontSize: 20,
+            marginBottom: -6,
           }}
           onClick={event => this.props.handleRemoveTag(event, tag)}
         />
@@ -88,7 +90,10 @@ class TagContainer extends React.Component<Props> {
         <MoreVertIcon
           data-tid={'tagMoreButton_' + tag.title.replace(/ /g, '_')}
           style={{
-            color: tag.textColor
+            color: tag.textColor,
+            marginLeft: -5,
+            marginRight: -5,
+            top: 0
           }}
         />
       );
@@ -104,7 +109,7 @@ class TagContainer extends React.Component<Props> {
         onDoubleClick={event => { if (this.props.handleTagMenu) { this.props.handleTagMenu(event, tag, entryPath || tagGroup); } }}
         style={{
           backgroundColor: 'transparent',
-          marginLeft: 4,
+          marginRight: 2,
           marginTop: 0,
           marginBottom: 4,
           display: 'inline-block'
@@ -118,12 +123,14 @@ class TagContainer extends React.Component<Props> {
             textTransform: 'none',
             color: textColor,
             backgroundColor,
-            minHeight: 25,
+            minHeight: 0,
+            minWidth: 0,
             margin: 0,
             paddingTop: 0,
             paddingBottom: 0,
-            paddingRight: 3,
-            borderRadius: 5
+            paddingRight: 0,
+            paddingLeft: 5,
+            borderRadius: 5,
           }}
         >
           <span>

--- a/app/perspectives/grid-perspective/src/index.js
+++ b/app/perspectives/grid-perspective/src/index.js
@@ -746,12 +746,9 @@ class GridPerspective extends React.Component<Props, State> {
       );
     } else if (this.state.layoutType === 'row') {
       return (
-        <Grid container wrap="nowrap" spacing={16}>
+        <Grid container wrap="nowrap">
           <Grid
             item
-            style={{
-              padding: 10
-            }}
           >
             {fsEntry.isFile ? (
               <div
@@ -771,11 +768,7 @@ class GridPerspective extends React.Component<Props, State> {
             )}
           </Grid>
           <Grid item xs zeroMinWidth>
-            <Typography
-              style={{
-                padding: 5
-              }}
-            >
+            <Typography>
               {extractTitle(fsEntry.name, !fsEntry.isFile)}
             </Typography>
             {fsEntry.tags.map(tag => this.renderTag(tag, fsEntry))}
@@ -783,7 +776,6 @@ class GridPerspective extends React.Component<Props, State> {
               // noWrap
               style={{
                 color: 'gray',
-                padding: 5
               }}
             >
               <span title={fsEntry.size + ' ' + i18n.t('core:sizeInBytes')}>
@@ -806,20 +798,15 @@ class GridPerspective extends React.Component<Props, State> {
           {fsEntry.thumbPath && (
             <Grid
               item
-              style={
-                {
-                  // margin: 5,
-                }
-              }
             >
               <div
                 className={classes.gridCellThumb}
                 style={{
                   backgroundSize: this.state.thumbnailMode,
                   backgroundImage: thumbPathUrl,
-                  margin: 5,
-                  height: 85,
-                  width: 85
+                  margin: 1,
+                  height: 65,
+                  width: 65
                 }}
               />
             </Grid>


### PR DESCRIPTION
The TagContainer and list view used to have a bunch of unneeded paddings, margins and minWidths that made the entry components bigger than necessary. Now, more entries fit on the screen without having reduced the font size.

Compare before and after:
![compact_01](https://user-images.githubusercontent.com/1915778/51992957-3d211b00-24ae-11e9-92aa-2f097240f7a7.jpg)
![compact_02](https://user-images.githubusercontent.com/1915778/51992961-3e524800-24ae-11e9-8fc3-4b07e96d77d4.jpg)
