### PR TITLE
Fix tagContainer not updating correctly

### DIFF
--- a/app/components/TagContainer.js
+++ b/app/components/TagContainer.js
@@ -45,11 +45,26 @@ type Props = {
 
 class TagContainer extends React.Component<Props> {
   shouldComponentUpdate(nextProps) {
-    if (this.props.tag !== nextProps.tag
-      || this.props.key !== nextProps.key
-      || this.props.tagGroup !== nextProps.tagGroup
+    if (this.props.tag.title !== nextProps.tag.title
+      || typeof this.props.key !== typeof nextProps.key
+      || (this.props.key && nextProps.key && this.props.key !== nextProps.key)
+      || this.props.tag.color !== nextProps.tag.color
+      || this.props.tag.textcolor !== nextProps.tag.textcolor
+      || this.props.allTags.some((currentTag: Tag) => {
+        if (currentTag.title === this.props.tag.title) {
+          return (nextProps.allTags.some((updatedTag: Tag) => {
+            if (updatedTag.title === this.props.tag.title) {
+              return currentTag.color !== updatedTag.color || currentTag.textcolor !== updatedTag.textcolor;
+            }
+            return false;
+          }));
+        }
+        return false;
+      })
+      || (this.props.tagGroup && this.props.tagGroup ? (this.props.tagGroup.uuid !== nextProps.tagGroup.uuid) : false)
       || this.props.isDragging !== nextProps.isDragging
-      || this.props.entryPath !== nextProps.entryPath
+      || typeof this.props.entryPath !== typeof nextProps.entryPath
+      || (this.props.entryPath && this.props.entryPath !== nextProps.entryPath)
     ) {
       return true;
     }

--- a/app/components/TagContainerDnd.js
+++ b/app/components/TagContainerDnd.js
@@ -81,11 +81,15 @@ class TagContainerDnd extends React.Component<Props> {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (this.props.tag !== nextProps.tag
-      || this.props.key !== nextProps.key
-      || this.props.tagGroup !== nextProps.tagGroup
+    if (this.props.tag.title !== nextProps.tag.title
+      || typeof this.props.key !== typeof nextProps.key
+      || (this.props.key && nextProps.key && this.props.key !== nextProps.key)
+      || this.props.tag.color !== nextProps.tag.color
+      || this.props.tag.textcolor !== nextProps.tag.textcolor
+      || (this.props.tagGroup && this.props.tagGroup ? (this.props.tagGroup.uuid !== nextProps.tagGroup.uuid) : false)
       || this.props.isDragging !== nextProps.isDragging
-      || this.props.entryPath !== nextProps.entryPath
+      || typeof this.props.entryPath !== typeof nextProps.entryPath
+      || (this.props.entryPath && this.props.entryPath !== nextProps.entryPath)
     ) {
       return true;
     }


### PR DESCRIPTION
This is a follow up to https://github.com/tagspaces/tagspaces/pull/892
The color of the tags on entries actually comes from the allTags prop.

It seems like there are a bunch of compound object/array props passed to the tagContainer but the container only uses a tiny part of that. The tagGroup for example has lots of info, but the tagContainer only needs the uuid. Similarly only one entry from the allTags array is needed. I wonder if it would be worth refactoring that a bit. I guess there are more important things atm.