### PR TITLE
Make thumb bg color configurable

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -37,6 +37,7 @@ export default {
   tagDelimiter: ' ',
   prefixTagContainer: '',
   maxThumbSize: 400,
+  thumbBgColor: 'black',
   indexerLimit: 200000,
   // maxSearchResult: 1000,
   defaultFileColor: '#808080',

--- a/app/services/thumbsgenerator.js
+++ b/app/services/thumbsgenerator.js
@@ -30,6 +30,7 @@ import PlatformIO from '../services/platform-io';
 import { Pro } from '../pro';
 
 const maxSize = AppConfig.maxThumbSize;
+const bgColor = AppConfig.thumbBgColor;
 
 const supportedImgs = ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'bmp'];
 const supportedContainers = [
@@ -266,6 +267,8 @@ function generateImageThumbnail(fileURL) {
 
         ctx.translate(x, y);
         ctx.rotate(angleInRadians);
+        ctx.fillStyle = bgColor;
+        ctx.fillRect(-width / 2, -height / 2, width, height);
         ctx.drawImage(img, -width / 2, -height / 2, width, height);
         ctx.rotate(-angleInRadians);
         ctx.translate(-x, -y);


### PR DESCRIPTION
It can be useful to have different background colour configurations for the thumbnails. This provides that as a global config.

It might also be worthwhile to make this an explicit user configuration in the user settings too.