### PR TITLE
Fixing falsey bug for when settings.orderby == false

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Change to the branch with the name **develop**:
 
 and install the project dependencies:
 
+    $ yarn install
+
+**Note:** If you experience any errors with the above command, please try this command first before filing a bug report:
+
     $ yarn install --network-timeout 1000000
 
 The last command will automatically build the application with webpack. Now it is time to install all the TagSpaces extensions:

--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ Change to the branch with the name **develop**:
 
 and install the project dependencies:
 
-    $ yarn install
+    $ yarn install --network-timeout 1000000
 
 The last command will automatically build the application with webpack. Now it is time to install all the TagSpaces extensions:
 
 	$ yarn install-ext
 
-Now you are ready and can start the application with:
+Now you are ready and can build/start (bs) the application with:
 
-	$ yarn start
+	$ yarn bs
 
 If you want to try the development mode, you can start it by:
 

--- a/app/perspectives/grid-perspective/components/MainContainer.tsx
+++ b/app/perspectives/grid-perspective/components/MainContainer.tsx
@@ -147,7 +147,10 @@ class GridPerspective extends React.Component<Props, State> {
       optionsContextMenuAnchorEl: null,
       selectedEntryPath: '',
       sortBy: settings && settings.sortBy ? settings.sortBy : 'byName',
-      orderBy: settings && settings.orderBy ? settings.orderBy : true,
+      orderBy:
+        settings && typeof settings.orderBy !== 'undefined'
+          ? settings.orderBy
+          : true,
       layoutType:
         settings && settings.layoutType ? settings.layoutType : 'grid',
       singleClickAction:


### PR DESCRIPTION
This pull request solves the issues: https://github.com/tagspaces/tagspaces/issues/1115, https://github.com/tagspaces/tagspaces/issues/1119, and https://github.com/tagspaces/tagspaces/issues/1118

The problem was when `settings.orderby == false`, it would cause the old inline if statement to become `false` and thus set the `orderby` value to the default `true`.

Link to description of the falsey issue (https://stackoverflow.com/questions/3390396/how-to-check-for-undefined-in-javascript).

The other commit adds the suggested fixes to the README.