### PR TITLE
Avoid MiTM by downloading through https

### DIFF
--- a/scripts/setup-tests.js
+++ b/scripts/setup-tests.js
@@ -41,7 +41,7 @@ extensionList.forEach(extension => {
 });
 
 // Download
-const winUrl = 'http://dl.min.io/server/minio/release/windows-amd64/minio.exe';
+const winUrl = 'https://dl.min.io/server/minio/release/windows-amd64/minio.exe';
 const linuxUrl = 'https://dl.min.io/server/minio/release/linux-amd64/minio';
 const macUrl = 'https://dl.min.io/server/minio/release/darwin-amd64/minio';
 const isWin = /^win/.test(process.platform);


### PR DESCRIPTION
Resources where downloaded through insecure connection enabling an attacker to intercept communications and replacing with malicious data, downloaded files are intended for execution

Replace http url with https for downloading resources

After fix Secure conection is stablished for downloads

Resources can be downloaded normally