### PR TITLE
Add drop in replacement for electron remote module will be removed in…

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -20,6 +20,8 @@ import { app, BrowserWindow, ipcMain, globalShortcut, dialog } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import path from 'path';
 
+require('@electron/remote/main').initialize();
+
 let mainWindow = null;
 (global as any).splashWorkerWindow = null;
 

--- a/app/services/electron-io.ts
+++ b/app/services/electron-io.ts
@@ -63,7 +63,7 @@ export default class ElectronIO {
       this.electron = window.require('electron');
       this.ipcRenderer = this.electron.ipcRenderer;
       this.webFrame = this.electron.webFrame;
-      this.remote = this.electron.remote;
+      this.remote = window.require('@electron/remote'); // this.electron.remote;
       this.workerWindow = this.remote.getGlobal('splashWorkerWindow');
       this.win = this.remote.getCurrentWindow();
       this.app = this.remote.app;

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "current-git-branch": "^1.1.0",
     "detect-port": "^1.3.0",
     "devtron": "^1.4.0",
-    "electron": "11.4.8",
+    "electron": "11.4.9",
     "electron-builder": "^22.10.5",
     "electron-devtools-installer": "^3.2.0",
     "enzyme": "^2.8.2",
@@ -242,6 +242,7 @@
   "dependencies": {
     "@aws-amplify/ui-react": "^1.0.7",
     "@date-io/date-fns": "^1.3.9",
+    "@electron/remote": "^1.2.0",
     "@gorillastack/jmespath": "^1.3.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,6 +3153,11 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
+"@electron/remote@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-1.2.0.tgz#772eb4c3ac17aaba5a9cf05a09092f6277f5671f"
+  integrity sha512-C774t2DFVJsa+dxU9Gc2nYzylRZoJ79I0Sxrh8T9cN69fBkntfGbyBEQiD9UfZopqL0CYLzk1anY2Ywhql6h1w==
+
 "@electron/universal@1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.0.4.tgz#231ac246c39d45b80e159bd21c3f9027dcaa10f5"
@@ -7940,10 +7945,10 @@ electron-window-state@^5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@11.4.8:
-  version "11.4.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.8.tgz#6f89be903bd917bda52afacf7cd3bdf2154b5c79"
-  integrity sha512-NrxlDZN1sWiDCWWOm5aX+tPGtiLgsCUwNqNFP3eJfY+RPdYLsxYRJDFa1vc4GcuCZEp9kZusINjmpPWsvJdspQ==
+electron@11.4.9:
+  version "11.4.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-11.4.9.tgz#87a4ab8a355853738e17e89832c57c4cbf9d55c0"
+  integrity sha512-3TJG1vAnuR8p47mzorCW5l7uWCjdNUufIbZ+gKjm010dtHmhrO1zchP1a76vuT4BllK8q1iygFSkNnDlZ0i2pA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
… Electron 14. It is replaced by @electron/remote