### PR TITLE
Implemented Basic Multiselect For Touch Screens

### DIFF
--- a/app/perspectives/grid-perspective/components/MainContainer.tsx
+++ b/app/perspectives/grid-perspective/components/MainContainer.tsx
@@ -222,7 +222,7 @@ function GridPerspective(props: Props) {
   const [ignored, forceUpdate] = useReducer(x => x + 1, 0);
 
   useEffect(() => {
-    makeFirstSelectedEntryVisible();
+    updateTouchSelectMode();
   }, [props.selectedEntries]);
 
   useEffect(() => {
@@ -331,17 +331,20 @@ function GridPerspective(props: Props) {
     [props.directoryContent, sortBy.current, orderBy.current]
   );
 
-  const makeFirstSelectedEntryVisible = () => {
+  const updateTouchSelectMode = () => {
+    const { selectedEntries } = props;
+    if (selectedEntries && selectedEntries.length == 0)
+      setIsTouchMultiSelectActive(false);
+  };
+
+  const makeEntryVisible = (fsEntry: TS.FileSystemEntry) => {
     const { selectedEntries } = props;
     if (selectedEntries && selectedEntries.length > 0) {
-      const firstSelectedElement = document.querySelector(
-        '[data-entry-id="' + selectedEntries[0].uuid + '"]'
+      const selectedElement = document.querySelector(
+        '[data-entry-id="' + fsEntry.uuid + '"]'
       );
-      if (
-        isObj(firstSelectedElement) &&
-        !isVisibleOnScreen(firstSelectedElement)
-      ) {
-        firstSelectedElement.scrollIntoView(false);
+      if (isObj(selectedElement) && !isVisibleOnScreen(selectedElement)) {
+        selectedElement.scrollIntoView(false);
       }
     }
   };
@@ -439,6 +442,14 @@ function GridPerspective(props: Props) {
     }
   };
 
+  const [isTouchMultiSelectActive, setIsTouchMultiSelectActive] = useState<
+    boolean
+  >(false);
+
+  const toggleTouchMultiSelectMode = () => {
+    setIsTouchMultiSelectActive(!isTouchMultiSelectActive);
+  };
+
   const clearSelection = () => {
     props.setSelectedEntries([]);
     selectedEntryPath.current = undefined;
@@ -452,7 +463,8 @@ function GridPerspective(props: Props) {
     currentDirectoryPath
   } = props;
 
-  const someFileSelected = selectedEntries.length > 1;
+  const someFileSelected =
+    selectedEntries.length > 1 || isTouchMultiSelectActive;
 
   const toggleSelectAllFiles = () => {
     if (someFileSelected) {
@@ -590,6 +602,7 @@ function GridPerspective(props: Props) {
 
   const selectEntry = (fsEntry: TS.FileSystemEntry) => {
     const { setSelectedEntries } = props;
+    makeEntryVisible(fsEntry);
     setSelectedEntries([...selectedEntries, fsEntry]);
   };
 
@@ -712,6 +725,8 @@ function GridPerspective(props: Props) {
           handleGridContextMenu={handleGridContextMenu}
           handleGridCellDblClick={handleGridCellDblClick}
           handleGridCellClick={handleGridCellClick}
+          isTouchMultiSelectActive={isTouchMultiSelectActive}
+          toggleTouchMultiSelectMode={toggleTouchMultiSelectMode}
         />
       </TagDropContainer>
     );

--- a/app/perspectives/list/components/MainContainer.tsx
+++ b/app/perspectives/list/components/MainContainer.tsx
@@ -222,7 +222,7 @@ function GridPerspective(props: Props) {
   const [ignored, forceUpdate] = useReducer(x => x + 1, 0);
 
   useEffect(() => {
-    makeFirstSelectedEntryVisible();
+    updateTouchSelectMode();
   }, [props.selectedEntries]);
 
   useEffect(() => {
@@ -331,17 +331,20 @@ function GridPerspective(props: Props) {
     [props.directoryContent, sortBy.current, orderBy.current]
   );
 
-  const makeFirstSelectedEntryVisible = () => {
+  const updateTouchSelectMode = () => {
+    const { selectedEntries } = props;
+    if (selectedEntries && selectedEntries.length == 0)
+      setIsTouchMultiSelectActive(false);
+  };
+
+  const makeEntryVisible = (fsEntry: TS.FileSystemEntry) => {
     const { selectedEntries } = props;
     if (selectedEntries && selectedEntries.length > 0) {
-      const firstSelectedElement = document.querySelector(
-        '[data-entry-id="' + selectedEntries[0].uuid + '"]'
+      const selectedElement = document.querySelector(
+        '[data-entry-id="' + fsEntry.uuid + '"]'
       );
-      if (
-        isObj(firstSelectedElement) &&
-        !isVisibleOnScreen(firstSelectedElement)
-      ) {
-        firstSelectedElement.scrollIntoView(false);
+      if (isObj(selectedElement) && !isVisibleOnScreen(selectedElement)) {
+        selectedElement.scrollIntoView(false);
       }
     }
   };
@@ -452,7 +455,16 @@ function GridPerspective(props: Props) {
     currentDirectoryPath
   } = props;
 
-  const someFileSelected = selectedEntries.length > 1;
+  const [isTouchMultiSelectActive, setIsTouchMultiSelectActive] = useState<
+    boolean
+  >(false);
+
+  const toggleTouchMultiSelectMode = () => {
+    setIsTouchMultiSelectActive(!isTouchMultiSelectActive);
+  };
+
+  const someFileSelected =
+    selectedEntries.length > 1 || isTouchMultiSelectActive;
 
   const toggleSelectAllFiles = () => {
     if (someFileSelected) {
@@ -590,6 +602,7 @@ function GridPerspective(props: Props) {
 
   const selectEntry = (fsEntry: TS.FileSystemEntry) => {
     const { setSelectedEntries } = props;
+    makeEntryVisible(fsEntry);
     setSelectedEntries([...selectedEntries, fsEntry]);
   };
 
@@ -712,6 +725,8 @@ function GridPerspective(props: Props) {
           handleGridContextMenu={handleGridContextMenu}
           handleGridCellDblClick={handleGridCellDblClick}
           handleGridCellClick={handleGridCellClick}
+          isTouchMultiSelectActive={isTouchMultiSelectActive}
+          toggleTouchMultiSelectMode={toggleTouchMultiSelectMode}
         />
       </TagDropContainer>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "source-map-support": "^0.5.21",
         "tiff.js": "^1.0.0",
         "ts-react-splitter": "^3.0.0",
+        "use-long-press": "^2.0.2",
         "use-state-with-callback": "^2.0.3",
         "uuid": "^8.3.2",
         "winattr": "^3.0.0"
@@ -47531,6 +47532,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-long-press": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-2.0.2.tgz",
+      "integrity": "sha512-zQ4sujilCykA7fSZ+m2gDuGw5aW3Gm3M4pulRH4e8c4mGXw8MDQIMthCsHiolxpt/hCe/BbIvd/iDn9XNDzkYg==",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/use-memo-one": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
@@ -87681,6 +87694,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-long-press": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/use-long-press/-/use-long-press-2.0.2.tgz",
+      "integrity": "sha512-zQ4sujilCykA7fSZ+m2gDuGw5aW3Gm3M4pulRH4e8c4mGXw8MDQIMthCsHiolxpt/hCe/BbIvd/iDn9XNDzkYg==",
+      "requires": {}
     },
     "use-memo-one": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "source-map-support": "^0.5.21",
     "tiff.js": "^1.0.0",
     "ts-react-splitter": "^3.0.0",
+    "use-long-press": "^2.0.2",
     "use-state-with-callback": "^2.0.3",
     "uuid": "^8.3.2",
     "winattr": "^3.0.0"


### PR DESCRIPTION
Basically, this alters the following:
- The First Item is No Longer Always Forced into View Upon Changing the Selection, rather now the item that gets selected gets focused, this is so you don't lose where you were when you were selecting items outside of the view of the first item.
- Long Pressing an Item enters a Multi-select mode where all touches get registered for selection/deselection, to exit simply unselect everything or uncheck the select all checkbox
