### PR TITLE
fix Search results lost on double-click

### DIFF
--- a/app/perspectives/grid-perspective/components/CellContent.tsx
+++ b/app/perspectives/grid-perspective/components/CellContent.tsx
@@ -532,7 +532,7 @@ function CellContent(props: Props) {
       }}
       onContextMenu={event => handleGridContextMenu(event, fSystemEntry)}
       onDoubleClick={event => {
-        props.exitSearchMode();
+        // props.exitSearchMode();
         handleGridCellDblClick(event, fSystemEntry);
       }}
       onClick={event => {


### PR DESCRIPTION
Search results get lost after opening a file via double-click https://github.com/tagspaces/tagspaces/issues/1913