### PR TITLE
fix load directory with default perspective from KanBan

### DIFF
--- a/app/components/FolderContainer.tsx
+++ b/app/components/FolderContainer.tsx
@@ -70,7 +70,7 @@ import {
 } from '-/reducers/location-index';
 import { PerspectiveIDs, AvailablePerspectives } from '-/perspectives';
 import MainSearchField from '-/components/MainSearchField';
-import LoadingAnimation from '-/components/LoadingAnimation';
+// import LoadingAnimation from '-/components/LoadingAnimation';
 import SearchBox from '-/components/SearchBox';
 import useFirstRender from '-/utils/useFirstRender';
 
@@ -634,7 +634,7 @@ function FolderContainer(props: Props) {
             width: '100%'
           }}
         >
-          <LoadingAnimation />
+          {/*<LoadingAnimation />*/}
           {renderPerspective()}
           {isRenameEntryDialogOpened && (
             <RenameEntryDialog

--- a/app/reducers/app.ts
+++ b/app/reducers/app.ts
@@ -388,7 +388,7 @@ export default (state: any = initialState, action: any) => {
         currentDirectoryPerspective:
           action.directoryMeta && action.directoryMeta.perspective
             ? action.directoryMeta.perspective
-            : state.currentDirectoryPerspective,
+            : action.defaultPerspective, // state.currentDirectoryPerspective,
         currentDirectoryPath: directoryPath,
         /**
          * used for reorder files in KanBan
@@ -1515,7 +1515,7 @@ export const actions = {
     directoryPath: string,
     directoryContent: Array<any>,
     directoryMeta?: TS.FileSystemEntryMeta
-  ) => (dispatch: (action) => void) => {
+  ) => (dispatch: (action) => void, getState: () => any) => {
     // const currentLocation: Location = getLocation(
     //  getState(),
     //  getState().app.currentLocationId
@@ -1537,13 +1537,15 @@ export const actions = {
         dispatch(actions.setSelectedEntries(newSelectedEntries));
       }
     } */
+    const { settings } = getState();
     dispatch(actions.hideNotifications(['error']));
     dispatch(
       actions.loadDirectorySuccessInt(
         directoryPath,
         directoryContent,
         false,
-        directoryMeta
+        directoryMeta,
+        settings.defaultPerspective
       )
     );
     dispatch(actions.setIsMetaLoaded(false));
@@ -1552,13 +1554,15 @@ export const actions = {
     directoryPath: string,
     directoryContent: Array<any>,
     showIsLoading?: boolean,
-    directoryMeta?: TS.FileSystemEntryMeta
+    directoryMeta?: TS.FileSystemEntryMeta,
+    defaultPerspective?: string
   ) => ({
     type: types.LOAD_DIRECTORY_SUCCESS,
     directoryPath: directoryPath || PlatformIO.getDirSeparator(),
     directoryContent,
     directoryMeta,
-    showIsLoading
+    showIsLoading,
+    defaultPerspective
   }),
   setDirectoryMeta: (directoryMeta: TS.FileSystemEntryMeta) => ({
     type: types.SET_DIRECTORY_META,

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "skip:husky:pre-commit": "node -e \"require('fs').rename('./.git/hooks/pre-commit', './.git/hooks/pre-commit.disabled', function(err) { if (err) console.log(err); console.log('File successfully renamed!') })\"",
     "sort-package-json": "npx sort-package-json",
     "source-map": "npm run source-map-app && npm run source-map-web && npm run source-map-cordova",
-    "source-map-app": "source-map-explorer app/dist/*.* --html reports/source-map-app.html",
+    "source-map-app": "npx source-map-explorer app/dist/*.* --html reports/source-map-app.html",
     "source-map-cordova": "source-map-explorer cordova/www/dist/*.* --html reports/source-map-cordova.html",
     "source-map-web": "source-map-explorer web/dist/*.* --html reports/source-map-web.html",
     "start": "cross-env NODE_ENV=production electron ./app/",


### PR DESCRIPTION
This PR fix this issue:
1. Load location1 with KanBan perspective (set in Location properties)
2. Switch to on other location2 with default perspective (unspecified in Location properties)

location2 will be loaded on first rerender in KanBan perspective and next in default GridPerspective