### PR TITLE
Fixed incorrect titles in both Chinese and Japanese

### DIFF
--- a/src/renderer/reducers/settings-default.ts
+++ b/src/renderer/reducers/settings-default.ts
@@ -135,7 +135,7 @@ export default {
     },
     {
       iso: 'zh_CN',
-      title: '中国的 (Chinese)',
+      title: '简体中文 (Chinese)',
     },
     {
       iso: 'bg',
@@ -143,7 +143,7 @@ export default {
     },
     {
       iso: 'ja',
-      title: '日本の (Japanese)',
+      title: '日本語 (Japanese)',
     },
     {
       iso: 'pt_BR',
@@ -203,7 +203,7 @@ export default {
     },
     {
       iso: 'zh_TW',
-      title: '台灣 (Chinese Taiwan)',
+      title: '繁体中文（台灣） (Chinese Taiwan)',
     },
     {
       iso: 'hu',
@@ -227,7 +227,7 @@ export default {
     },
     {
       iso: 'zh_HK',
-      title: '漢語 (Chinese Hong Kong)',
+      title: '繁体中文（香港） (Chinese Hong Kong)',
     },
     {
       iso: 'he',


### PR DESCRIPTION
- Originally it was "中国的", where "中国" means China and "的" is a auxiliary word. It has been changed to "简体中文" (Simplified Chinese).
- Similarly, "日本の", where "日本" means Japan and "の" is a auxiliary word, has been changed to 日本語 (Japanese Language).

The cause of the above two issues is that when translating "Chinese" and "Japanese," the translation used their adjectival meanings rather than their meanings as language names.

- "台灣" is a regional name and should not be used as a language name. It has been changed to "繁体中文（台灣）" (Traditional Chinese, Taiwan).
- "漢語" means Chinese. Although it is written in Traditional Chinese, it lacks sufficient distinction. It has been changed to "繁体中文（香港）" (Traditional Chinese, Hongkong).