### PR TITLE
Remove autoFocus from Tags field

### DIFF
--- a/src/renderer/components/EntryProperties.tsx
+++ b/src/renderer/components/EntryProperties.tsx
@@ -612,7 +612,6 @@ function EntryProperties({ tileServer }: Props) {
               tagMode="default"
               handleChange={handleChange}
               selectedEntry={openedEntry}
-              autoFocus={true}
               generateButton={true}
             />
           </TagDropContainer>


### PR DESCRIPTION
When clicking on any file in a folder the default behaviour is to auto-focus the cursor on the Tags field. This is problematic for keyboard-focused workflows e.g. using arrow keys to move to different files in the folder, using the delete key to delete several files from a folder, or any of the other keyboard shortcuts for interacting with files in a folder. This PR therefore removes auto-focus from the Tags field.