### PR TITLE
Add ENTER key support to ConfirmDialog

### DIFF
--- a/src/renderer/components/dialogs/ConfirmDialog.tsx
+++ b/src/renderer/components/dialogs/ConfirmDialog.tsx
@@ -73,12 +73,21 @@ function ConfirmDialog(props: Props) {
     onClose();
   }
 
+  function handleKeyDown(event: React.KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      onConfirm(true);
+    }
+  }
+
   return (
     <Dialog
       aria-labelledby="draggable-dialog-title"
       PaperComponent={DraggablePaper}
       open={open}
       onClose={onClose}
+      onKeyDown={handleKeyDown}
       keepMounted
       scroll="paper"
       sx={{ zIndex: 1301 }}

--- a/tests/e2e/key-bindings.pw.e2e.js
+++ b/tests/e2e/key-bindings.pw.e2e.js
@@ -102,6 +102,22 @@ test.describe('TST13 - Settings Key Bindings [electron]', () => {
     await expectElementExist(getGridFileSelector(testFileName), false);
   });
 
+  test('TST13151 - Test delete file with ENTER key on confirm dialog [electron,minio,s3]', async () => {
+    const testFile = 'sample.txt';
+    await clickOn(getGridFileSelector(testFile));
+    if (isMac) {
+      await global.client.keyboard.press('F8');
+    } else {
+      await global.client.keyboard.press('Delete');
+    }
+    // Wait for confirm dialog to appear
+    await expectElementExist('[data-tid=confirmDeleteFileDialog]', true, 5000);
+    // Press ENTER to confirm deletion
+    await global.client.keyboard.press('Enter');
+    // Verify file was deleted
+    await expectElementExist(getGridFileSelector(testFile), false);
+  });
+
   test('TST1316 - Show help and feedback panel in the left [electron,minio,s3]', async () => {
     await clickOn(getGridFileSelector('sample.txt'));
     await global.client.keyboard.press('F1');


### PR DESCRIPTION
The "Confirm delete" pop-up gives the user the choice of "Yes" or "No", but there's currently no handling for the "ENTER" key as "Yes" which is common to many confirmation pop-ups. This PR adds ENTER key handling. 