### PR TITLE
🚀 Feature: Add configurable filename tag syntax default to app config

### DIFF
--- a/src/renderer/AppConfig.ts
+++ b/src/renderer/AppConfig.ts
@@ -172,6 +172,12 @@ AppConfig.defaultSpaceBetweenButtons = '10px';
 AppConfig.aiFolder = 'ai';
 AppConfig.aiChatFileName = 'tsc.json';
 AppConfig.sidecarRevisionExtension = '.meta';
+AppConfig.FilenameTagFormats = {
+  squareBrackets: 'squareBrackets',
+  parentheses: 'parentheses',
+  atSign: 'atSign',
+};
+AppConfig.ExtFilenameTagFormat = AppConfig.FilenameTagFormats.squareBrackets;
 AppConfig.ExtDefaultMapBounds = {
   southWest: { lat: 56, lng: -13 },
   northEast: { lat: 29, lng: 50 },


### PR DESCRIPTION
## Problem

Add a new configuration field for filename tag syntax so the app can store and expose which delimiter style should be used when writing tags into filenames. This must default to current behavior (`[]`) to remain backward-compatible.

**Severity**: `medium`
**File**: `src/renderer/AppConfig.ts`

## Solution

Introduce a typed option such as `filenameTagFormat` (or `ExtFilenameTagFormat` for external config parity) with allowed values like `squareBrackets | parentheses | atSign`. Set default to `squareBrackets`. Keep existing options (e.g., `ExtFilenameTagPlacedAtEnd`) unchanged and make this new field orthogonal to placement.

## Changes

- `src/renderer/AppConfig.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #1826