### PR TITLE
🚀 Feature: Ensure Escape shortcut definition is a real command (not just UI text)

### DIFF
--- a/src/renderer/reducers/settings.ts
+++ b/src/renderer/reducers/settings.ts
@@ -125,12 +125,54 @@ export default (state: any = defaultSettings, action: any) => {
       // const currentVersion = semver.coerce(versionMeta.version);
       // console.log('---->' + currentVersion);
 
+      const normalizedStateKeyBindings = (state.keyBindings || []).map(
+        (keyBinding) => {
+          const normalizedKeyBinding = { ...keyBinding };
+
+          if (normalizedKeyBinding.name === 'Escape') {
+            normalizedKeyBinding.name = 'closeOrCancel';
+          }
+
+          if (
+            typeof normalizedKeyBinding.key === 'string' &&
+            normalizedKeyBinding.key.toLowerCase() === 'esc'
+          ) {
+            normalizedKeyBinding.key = 'Escape';
+          }
+
+          if (
+            typeof normalizedKeyBinding.shortcut === 'string' &&
+            normalizedKeyBinding.shortcut.toLowerCase() === 'esc'
+          ) {
+            normalizedKeyBinding.shortcut = 'Escape';
+          }
+
+          if (
+            typeof normalizedKeyBinding.accelerator === 'string' &&
+            normalizedKeyBinding.accelerator.toLowerCase() === 'esc'
+          ) {
+            normalizedKeyBinding.accelerator = 'Escape';
+          }
+
+          return normalizedKeyBinding;
+        },
+      );
+
       const mergedKeyBindings = defaultSettings.keyBindings.map((x) =>
         Object.assign(
           x,
-          state.keyBindings.find((y) => y.name === x.name),
+          normalizedStateKeyBindings.find((y) => y.name === x.name),
         ),
       );
+
+      mergedKeyBindings.forEach((keyBinding) => {
+        if (keyBinding.name === 'Escape') {
+          keyBinding.name = 'closeOrCancel';
+        }
+        if (keyBinding.name === 'closeOrCancel' && !keyBinding.command) {
+          keyBinding.command = 'closeOrCancel';
+        }
+      });
 
       const explicitlyDeletedTypes = state.explicitlyDeletedFileTypes || [];
       const defaultFileTypes = defaultSettings.supportedFileTypes.filter(


### PR DESCRIPTION
## Problem

The issue report indicates Escape appears in the shortcuts UI but is not actually wired. The settings reducer is the canonical place where default keybindings/shortcut metadata are typically defined and persisted. This file should be updated so Escape maps to a concrete command ID used by runtime shortcut registration (for example `closeOrCancel`), with normalized key value (`Escape` + `esc` alias support).

**Severity**: `medium`
**File**: `src/renderer/reducers/settings.ts`

## Solution

Add/update the default shortcut entry for Escape to point to a dedicated command (e.g. `ESCAPE_ACTION` / `closeOrCancel`). Make sure:

## Changes

- `src/renderer/reducers/settings.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #1787